### PR TITLE
Fix region and account config via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Lambda function are invoked with `(event, context[, callback])` where the
 
 - `functionName`: The name of the Lambda function.
 - `invokedFunctionArn`: The function ARN, build from the `AWS_REGION`
-  (defaulting to `us-east-1`), `STUDIO_AWS_ACCOUNT` (defaulting to `0000`) and
-  the Lambda function name.
+  (defaulting to `us-east-1`), `STUDIO_AWS_ACCOUNT` (defaulting to
+  `000000000000`) and the Lambda function name.
 - `memoryLimitInMB`: The configured memory limit. This is currently not
   enforced.
 - `awsRequestId`: The AWS request ID, either from `options` or generated.

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -14,6 +14,8 @@ const ParseTransform = require('@studio/ndjson/parse');
 const DEFAULT_LAMBDA_TIMEOUT = 5;
 const DEFAULT_LAMBDA_MEMORY = 128;
 const DEFAULT_LAMBDA_MAX_IDLE = 60 * 60 * 1000;
+const DEFAULT_AWS_REGION = 'us-east-1';
+const DEFAULT_AWS_ACCOUNT = '000000000000';
 
 const log = logger('Lambda');
 
@@ -92,8 +94,8 @@ function forkLambda(
       LAMBDA_TASK_ROOT: cwd,
       AWS_EXECUTION_ENV: 'AWS_Lambda_nodejs6.10',
       AWS_PROFILE: process.env.AWS_PROFILE,
-      AWS_REGION: process.env.AWS_REGION || 'us-east-1',
-      AWS_DEFAULT_REGION: process.env.AWS_REGION || 'us-east-1',
+      AWS_REGION: process.env.AWS_REGION || DEFAULT_AWS_REGION,
+      AWS_DEFAULT_REGION: process.env.AWS_REGION || DEFAULT_AWS_REGION,
       AWS_LAMBDA_FUNCTION_NAME: name,
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: memoryLimitInMB,
       AWS_LAMBDA_FUNCTION_VERSION: '1',
@@ -322,6 +324,7 @@ function forkPool(
         timeout,
         functionName: name,
         memoryLimitInMB: memory,
+        invokedFunctionArn: invokedFunctionArn(name),
         awsRequestId: options.awsRequestId || `${now()}_${name}_${++request_id}`
       };
       entry.active = true;
@@ -341,6 +344,12 @@ function forkPool(
       };
     }
   };
+}
+
+function invokedFunctionArn(function_name) {
+  const region = process.env.AWS_REGION || DEFAULT_AWS_REGION;
+  const account = process.env.STUDIO_AWS_ACCOUNT || DEFAULT_AWS_ACCOUNT;
+  return `arn:aws:lambda:${region}:${account}:function:${function_name}`;
 }
 
 exports.create = function (base_options = {}) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -5,12 +5,6 @@
 
 const lambda_module = require(`${process.cwd()}/${process.argv[2]}`);
 
-function invokedFunctionArn() {
-  const region = process.env.AWS_REGION;
-  const account = process.env.STUDIO_AWS_ACCOUNT || '0000';
-  return `arn:aws:lambda:${region}:${account}:function:${this.functionName}`;
-}
-
 function setGetRemainingTimeInMillis(context) {
   const ms_start = Date.now();
   const timeout = context.timeout;
@@ -22,9 +16,6 @@ function setGetRemainingTimeInMillis(context) {
 
 process.on('message', (m) => {
   const context = m.context;
-  Object.defineProperty(context, 'invokedFunctionArn', {
-    get: invokedFunctionArn
-  });
   setGetRemainingTimeInMillis(context);
 
   function handleResponse(err, data) {

--- a/test/lambda-test.js
+++ b/test/lambda-test.js
@@ -20,6 +20,8 @@ describe('lambda', () => {
   afterEach(() => {
     sinon.restore();
     lambda.shutdown();
+    delete process.env.AWS_REGION;
+    delete process.env.STUDIO_AWS_ACCOUNT;
   });
 
   it('invokes lambda with event', (done) => {
@@ -101,34 +103,30 @@ describe('lambda', () => {
         functionName: 'context',
         memoryLimitInMB: 128,
         awsRequestId: '000000123_context_1',
-        invokedFunctionArn: 'arn:aws:lambda:us-east-1:0000:function:context'
+        invokedFunctionArn:
+          'arn:aws:lambda:us-east-1:000000000000:function:context'
       });
       done();
     });
   });
 
   it('uses AWS_REGION environment variable in function ARN', (done) => {
-    lambda = Lambda.create({
-      env: {
-        AWS_REGION: 'eu-central-1'
-      }
-    });
+    process.env.AWS_REGION = 'eu-central-1';
+    lambda = Lambda.create();
 
     lambda.invoke('context', {}, (err, value) => {
       assert.isNull(err);
       assert.matchJson(value, {
-        invokedFunctionArn: 'arn:aws:lambda:eu-central-1:0000:function:context'
+        invokedFunctionArn:
+          'arn:aws:lambda:eu-central-1:000000000000:function:context'
       });
       done();
     });
   });
 
   it('uses STUDIO_AWS_ACCOUNT environment variable in function ARN', (done) => {
-    lambda = Lambda.create({
-      env: {
-        STUDIO_AWS_ACCOUNT: '12345678'
-      }
-    });
+    process.env.STUDIO_AWS_ACCOUNT = '12345678';
+    lambda = Lambda.create();
 
     lambda.invoke('context', {}, (err, value) => {
       assert.isNull(err);
@@ -146,7 +144,8 @@ describe('lambda', () => {
       assert.isNull(err);
       assert.matchJson(value, {
         awsRequestId: '666',
-        invokedFunctionArn: 'arn:aws:lambda:us-east-1:0000:function:context'
+        invokedFunctionArn:
+          'arn:aws:lambda:us-east-1:000000000000:function:context'
       });
       done();
     });
@@ -217,7 +216,6 @@ describe('lambda', () => {
     lambda.invoke('env', { env: 'AWS_REGION' }, (err, value) => {
       assert.isNull(err);
       assert.equals(value, 'Hello eu-central-1');
-      delete process.env.AWS_REGION;
       done();
     });
   });
@@ -239,7 +237,6 @@ describe('lambda', () => {
     lambda.invoke('env', { env: 'AWS_DEFAULT_REGION' }, (err, value) => {
       assert.isNull(err);
       assert.equals(value, 'Hello eu-central-1');
-      delete process.env.AWS_REGION;
       done();
     });
   });


### PR DESCRIPTION
Properly respect the `AWS_REGION` and `STUDIO_AWS_ACCOUNT` environment variables at startup time.