### PR TITLE
Fix max idle overtaking lambda timeout

### DIFF
--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -231,8 +231,8 @@ function forkLambda(
     invoke(event, context, callback) {
       if (idle_timer) {
         clearTimeout(idle_timer);
+        idle_timer = null;
       }
-      idle_timer = setTimeout(kill, max_idle);
       const i = ++id;
       const ms_timeout = timeout * 1000;
       if (!inspect_lambda) {
@@ -247,6 +247,8 @@ function forkLambda(
         clearTimeout(timeout_timer);
         if (graceful_shutdown) {
           kill();
+        } else if (!err) {
+          idle_timer = setTimeout(kill, max_idle);
         }
         callback(err, value);
       };

--- a/test/lambda-test.js
+++ b/test/lambda-test.js
@@ -476,6 +476,23 @@ describe('lambda', () => {
     });
   });
 
+  it('kills lambda after configured timeout if larger than max_idle', (done) => {
+    sinon.stub(log, 'warn');
+
+    lambda = Lambda.create({
+      max_idle: 25,
+      env: {
+        AWS_PROFILE: 'local'
+      }
+    });
+
+    lambda.invoke('timeout-file', {}, (err) => {
+      assert.json(err, { code: 'E_TIMEOUT' });
+      assert.calledOnce(log.warn);
+      done();
+    });
+  });
+
   it('does not fail to talk to lambda after two where killed', (done) => {
     sinon.stub(log, 'warn');
 


### PR DESCRIPTION
When `max_idle` is smaller than the lambda's configured timeout, the function was terminated too early.

With this patch, the idle timer is cleared on function invocation and started again when the lambda returned.